### PR TITLE
refactoring code to avoid repetition

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ struct Args {
     verbose: bool,
 }
 
+// UDP Connection is not really a thing since it's a stateless protocol,
+// but in our case UdpSocket +  SocketAddr -pair represents a "connection"
+// analogous to TcpStream
 pub struct UdpConnection {
     socket: UdpSocket,
     peer: SocketAddr,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use async_std::{
-    net::{TcpStream, UdpSocket},
+    net::{SocketAddr, TcpStream, UdpSocket},
     os::unix::net::{UnixDatagram, UnixStream},
 };
 
@@ -44,9 +44,14 @@ struct Args {
     verbose: bool,
 }
 
+pub struct UdpConnection {
+    socket: UdpSocket,
+    peer: SocketAddr,
+}
+
 pub enum Socket {
     TCP(TcpStream),
-    UDP(UdpSocket),
+    UDP(UdpConnection),
     UnixSocketStream(UnixStream),
     UnixSocketDatagram(UnixDatagram),
 }

--- a/src/std_socket_io.rs
+++ b/src/std_socket_io.rs
@@ -4,7 +4,7 @@ use futures::{AsyncReadExt, AsyncWriteExt};
 
 use crate::{Result, Socket};
 
-pub async fn stdin_to_socket(mut sock: Socket) -> Result<()> {
+async fn stdin_to_socket(mut sock: Socket) -> Result<()> {
     let mut stdin = io::stdin();
     let _res = match sock {
         Socket::TCP(ref mut stream) => io::copy(&mut stdin, stream).await?,
@@ -12,7 +12,6 @@ pub async fn stdin_to_socket(mut sock: Socket) -> Result<()> {
             let mut buf = [0u8; crate::BUFFER_SIZE];
             loop {
                 let read_bytes = io::stdin().read(&mut buf).await?;
-                eprintln!("Read {}", read_bytes);
                 let sent_bytes = match read_bytes {
                     1_usize..=usize::MAX => {
                         udp_connection
@@ -22,7 +21,6 @@ pub async fn stdin_to_socket(mut sock: Socket) -> Result<()> {
                     }
                     _ => break,
                 };
-                eprintln!("Sent {}", sent_bytes);
                 if sent_bytes == 0 {
                     break;
                 }
@@ -37,7 +35,7 @@ pub async fn stdin_to_socket(mut sock: Socket) -> Result<()> {
 
 // Generic implementation for udp/tcp to avoid duplicate code
 // Socket `socket` is an enum over async TcpStream, UdpSocket and Unix sockets
-pub async fn socket_to_stdout(mut socket: Socket) -> Result<()> {
+async fn socket_to_stdout(mut socket: Socket) -> Result<()> {
     let mut stdout = io::stdout();
     let mut buf = [0u8; crate::BUFFER_SIZE];
     loop {

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -46,10 +46,7 @@ pub async fn run_tcp_client(hostname: &str, target_port: u16, timeout: Option<u6
             )?;
             TcpStream::from(sync_stream)
         }
-        None => {
-            // Let's go with system's default timeout
-            TcpStream::connect(target).await?
-        }
+        None => TcpStream::connect(target).await?, // No timeout defined
     };
     let write_sock = Socket::TCP(stream.clone());
     let read_sock = Socket::TCP(stream);

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -54,7 +54,7 @@ pub async fn run_tcp_client(hostname: &str, target_port: u16, timeout: Option<u6
 }
 
 async fn run_tcpstream_tasks(stream: &mut TcpStream) -> Result<()> {
-    let stdin_task = std_socket_io::stdin_to_stream(Socket::TCP(stream.clone())).fuse();
+    let stdin_task = std_socket_io::stdin_to_socket(Socket::TCP(stream.clone())).fuse();
     let socket = Socket::TCP(stream.clone());
     let stdout_task = std_socket_io::socket_to_stdout(socket).fuse();
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -5,21 +5,30 @@ use futures::{future::FutureExt, pin_mut, select};
 
 use async_std::net::{ToSocketAddrs, UdpSocket};
 
-use crate::{std_socket_io, Args, Result, Socket};
+use crate::{std_socket_io, Args, Result, Socket, UdpConnection};
 
 pub async fn run_udp_client(hostname: &str, target_port: u16) -> Result<()> {
     let udp_socket = std::net::UdpSocket::bind("0.0.0.0:0")?;
-    let cloned_socket = udp_socket.try_clone()?;
-    let async_socket = UdpSocket::from(udp_socket);
-    let async_clone = Socket::UDP(UdpSocket::from(cloned_socket));
     let target = format!("{}:{}", hostname, target_port);
     let server = match target.to_socket_addrs().await?.next() {
         Some(server) => server,
         None => return Err("Empty socket address".into()),
     };
 
-    let stdin_task = std_socket_io::stdin_to_udpsocket(async_socket, server).fuse();
-    let stdout_task = std_socket_io::socket_to_stdout(async_clone).fuse();
+    let cloned_socket = udp_socket.try_clone()?;
+    let udp_conn_read = UdpConnection {
+        socket: UdpSocket::from(udp_socket),
+        peer: server,
+    };
+    let udp_conn_write = UdpConnection {
+        socket: UdpSocket::from(cloned_socket),
+        peer: server,
+    };
+    let conn_read = Socket::UDP(udp_conn_read);
+    let conn_write = Socket::UDP(udp_conn_write);
+
+    let stdin_task = std_socket_io::stdin_to_socket(conn_write).fuse();
+    let stdout_task = std_socket_io::socket_to_stdout(conn_read).fuse();
 
     pin_mut!(stdin_task, stdout_task);
     select! {
@@ -53,12 +62,20 @@ pub async fn run_udp_server(bind_addr: &str, bind_port: u16) -> Result<()> {
     io::stdout().flush().await?;
 
     let cloned_socket = udp_socket.try_clone()?;
-    let async_socket = UdpSocket::from(udp_socket);
 
-    let async_clone = Socket::UDP(UdpSocket::from(cloned_socket));
+    let udp_conn_read = UdpConnection {
+        socket: UdpSocket::from(udp_socket),
+        peer: peer,
+    };
+    let udp_conn_write = UdpConnection {
+        socket: UdpSocket::from(cloned_socket),
+        peer: peer,
+    };
+    let conn_read = Socket::UDP(udp_conn_read);
+    let conn_write = Socket::UDP(udp_conn_write);
 
-    let stdin_task = std_socket_io::stdin_to_udpsocket(async_socket, peer).fuse();
-    let stdout_task = std_socket_io::socket_to_stdout(async_clone).fuse();
+    let stdin_task = std_socket_io::stdin_to_socket(conn_write).fuse();
+    let stdout_task = std_socket_io::socket_to_stdout(conn_read).fuse();
 
     pin_mut!(stdin_task, stdout_task);
     select! {

--- a/src/unixstream.rs
+++ b/src/unixstream.rs
@@ -17,7 +17,7 @@ pub async fn run_unix_socket_server(addr: &str) -> Result<()> {
     }
     let sock_write = Socket::UnixSocketStream(sock.clone());
     let sock_read = Socket::UnixSocketStream(sock);
-    run_unixstream_tasks(sock_read, sock_write).await
+    std_socket_io::run_async_tasks(sock_read, sock_write).await
 }
 
 pub async fn run_unix_socket_client(addr: &str) -> Result<()> {
@@ -33,9 +33,9 @@ pub async fn run_unix_socket_client(addr: &str) -> Result<()> {
     run_unixstream_tasks(Socket::UnixSocketStream(sock), wsock).await
 }
 
-async fn run_unixstream_tasks(rsock: Socket, wsock: Socket) -> Result<()> {
-    let stdin_task = std_socket_io::stdin_to_socket(wsock).fuse();
-    let stdout_task = std_socket_io::socket_to_stdout(rsock).fuse();
+async fn run_unixstream_tasks(read_sock: Socket, write_sock: Socket) -> Result<()> {
+    let stdin_task = std_socket_io::stdin_to_socket(write_sock).fuse();
+    let stdout_task = std_socket_io::socket_to_stdout(read_sock).fuse();
     pin_mut!(stdin_task, stdout_task);
     select! {
         _res = stdin_task => _res,


### PR DESCRIPTION
Introduce a generic `run_async_tasks` function instead of custom case-specific invocation of async stuff.

Also a generic `stdin_to_socket` function instead of udp and tcp specific implementations.